### PR TITLE
Switch settings schema to point at location agent RDNN change

### DIFF
--- a/src/Views/LocationPanel.vala
+++ b/src/Views/LocationPanel.vala
@@ -22,6 +22,8 @@
 
 public class SecurityPrivacy.LocationPanel : ServicePanel {
 
+    private const string LOCATION_AGENT_ID = "io.elementary.desktop.agent-geoclue2";
+
     private GLib.Settings location_settings;
     private Variant remembered_apps;
     private VariantDict remembered_apps_dict;
@@ -45,7 +47,7 @@ public class SecurityPrivacy.LocationPanel : ServicePanel {
     }
 
     construct {
-        location_settings = new GLib.Settings ("org.pantheon.agent-geoclue2");
+        location_settings = new GLib.Settings (LOCATION_AGENT_ID);
         disabled_stack = new Gtk.Stack ();
         
         content_area.attach (disabled_stack, 0, 1, 3, 1);        
@@ -184,7 +186,7 @@ public class SecurityPrivacy.LocationPanel : ServicePanel {
 
     public static bool location_agent_installed () {
         var schemas = GLib.SettingsSchemaSource.get_default ();
-        if (schemas.lookup ("org.pantheon.agent-geoclue2", true) != null) {
+        if (schemas.lookup (LOCATION_AGENT_ID, true) != null) {
             return true;
         }
 


### PR DESCRIPTION
Required after https://github.com/elementary/pantheon-agent-geoclue2/pull/9