### PR TITLE
Broken exclude panel

### DIFF
--- a/src/Widgets/AppChooser.vala
+++ b/src/Widgets/AppChooser.vala
@@ -78,8 +78,8 @@ public class SecurityPrivacy.Dialogs.AppChooser : Gtk.Popover {
 
     int sort_function (Gtk.ListBoxRow list_box_row_1,
                        Gtk.ListBoxRow list_box_row_2) {
-        var row_1 = list_box_row_1.get_child () as AppRow;
-        var row_2 = list_box_row_2.get_child () as AppRow;
+        var row_1 = list_box_row_1 as AppRow;
+        var row_2 = list_box_row_2 as AppRow;
 
         var name_1 = row_1.app_info.get_display_name ();
         var name_2 = row_2.app_info.get_display_name ();
@@ -88,7 +88,7 @@ public class SecurityPrivacy.Dialogs.AppChooser : Gtk.Popover {
     }
 
     bool filter_function (Gtk.ListBoxRow list_box_row) {
-        var app_row = list_box_row.get_child () as AppRow;
+        var app_row = list_box_row as AppRow;
         string name = app_row.app_info.get_display_name ();
         if (name == null)
             name = app_row.app_info.get_name ();
@@ -101,7 +101,7 @@ public class SecurityPrivacy.Dialogs.AppChooser : Gtk.Popover {
     }
 
     void on_app_selected (Gtk.ListBoxRow list_box_row) {
-        var app_row = list_box_row.get_child () as AppRow;
+        var app_row = list_box_row as AppRow;
         app_chosen (app_row.app_info);
         hide ();
     }

--- a/src/Widgets/AppChooser.vala
+++ b/src/Widgets/AppChooser.vala
@@ -66,10 +66,7 @@ public class SecurityPrivacy.Dialogs.AppChooser : Gtk.Popover {
 
     public void init_list () {
         foreach (var app_info in AppInfo.get_all ()) {
-            if (app_info.should_show () == false)
-                continue;
-
-            if (app_info is DesktopAppInfo) {
+            if (app_info is DesktopAppInfo && app_info.should_show ()) {
                 var app_row = new AppRow ((DesktopAppInfo)app_info);
                 list.prepend (app_row);
             }

--- a/src/Widgets/ExcludeTreeView.vala
+++ b/src/Widgets/ExcludeTreeView.vala
@@ -89,6 +89,8 @@ public class ExcludeTreeView : Gtk.Grid {
             Gtk.TreePath path;
             Gtk.TreeViewColumn column;
             view.get_cursor (out path, out column);
+            if (path == null)
+                return;
             Gtk.TreeIter iter;
             list_store.get_iter (out iter, path);
             Value is_app;
@@ -134,7 +136,10 @@ public class ExcludeTreeView : Gtk.Grid {
         add (frame);
 
         view.cursor_changed.connect (() => {
-            remove_button.sensitive = true;
+            Gtk.TreePath path;
+            Gtk.TreeViewColumn column;
+            view.get_cursor (out path, out column);
+            remove_button.sensitive = (path != null);
         });
 
         Gtk.TreeIter iter;


### PR DESCRIPTION
- fixed filtering, adding and sorting in apps popup - related to issue #45

- disable remove button when there is no selection (switchboard crashes without this fix)