### PR TITLE
Change "sleep" to "suspend" to unify the notation

### DIFF
--- a/src/Views/LockPanel.vala
+++ b/src/Views/LockPanel.vala
@@ -32,7 +32,7 @@ public class SecurityPrivacy.LockPanel : Granite.SimpleSettingsPage {
     construct {
         locker = new Settings ("apps.light-locker");
 
-        var lock_suspend_label = new Gtk.Label (_("Lock on sleep:"));
+        var lock_suspend_label = new Gtk.Label (_("Lock on suspend:"));
         var lock_suspend_switch = new Gtk.Switch ();
         var lock_sleep_label = new Gtk.Label (_("Lock after screen turns off:"));
         var lock_sleep_switch = new Gtk.Switch ();


### PR DESCRIPTION
Fixes #50

In elementary OS, there are two notation of same meaning: "sleep" and "suspend". In most cases "suspend" is used, but there is one case which uses "sleep" remain. I think it would be better to unify the notation to "suspend" across the whole OS.
