### PR TITLE
 build: fix install path for switchboard plug

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -9,14 +9,14 @@ i18n.merge_file(
     output: '@BASENAME@',
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'polkit-1', 'actions')
+    install_dir: join_paths(datadir, 'polkit-1', 'actions')
 )
 
 i18n.merge_file(
     input: 'io.elementary.switchboard.security-privacy.appdata.xml.in',
     output: 'io.elementary.switchboard.security-privacy.appdata.xml',
     po_dir: join_paths(meson.source_root (), 'po', 'extra'),
-    install_dir: join_paths(get_option('datadir'), 'metainfo'),
+    install_dir: join_paths(datadir, 'metainfo'),
     install: true
 )
 
@@ -28,5 +28,5 @@ install_data(
 
 install_data(
     'io.elementary.switchboard.security-privacy.gschema.xml',
-    install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
+    install_dir: join_paths(datadir, 'glib-2.0', 'schemas')
 )

--- a/data/meson.build
+++ b/data/meson.build
@@ -9,7 +9,7 @@ i18n.merge_file(
     output: '@BASENAME@',
     po_dir: join_paths(meson.source_root(), 'po', 'extra'),
     install: true,
-    install_dir: join_paths(datadir, 'polkit-1', 'actions')
+    install_dir: polkit_actiondir
 )
 
 i18n.merge_file(

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,8 @@ datadir = join_paths(prefix, get_option('datadir'))
 libdir = join_paths(prefix, get_option('libdir'))
 
 switchboard_dep = dependency('switchboard-2.0')
-pkgdatadir = join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'personal')
+switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
+pkgdatadir = join_paths(switchboard_plugsdir, 'personal')
 
 add_project_arguments(
     '-DGETTEXT_PACKAGE="@0@"'.format(gettext_name),

--- a/meson.build
+++ b/meson.build
@@ -4,12 +4,16 @@ project(
     meson_version: '>= 0.46.1',
     version: '2.2.1'
 )
-
-switchboard_dep = dependency('switchboard-2.0')
+i18n = import('i18n')
 
 gettext_name = meson.project_name() + '-plug'
+
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+libdir = join_paths(prefix, get_option('libdir'))
+
+switchboard_dep = dependency('switchboard-2.0')
 pkgdatadir = join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'personal')
-i18n = import('i18n')
 
 add_project_arguments(
     '-DGETTEXT_PACKAGE="@0@"'.format(gettext_name),

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,9 @@ switchboard_dep = dependency('switchboard-2.0')
 switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 pkgdatadir = join_paths(switchboard_plugsdir, 'personal')
 
+polkit_dep = dependency('polkit-gobject-1')
+polkit_actiondir = polkit_dep.get_pkgconfig_variable('actiondir', define_variable: ['prefix', prefix])
+
 add_project_arguments(
     '-DGETTEXT_PACKAGE="@0@"'.format(gettext_name),
     language:'c'

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,9 +29,9 @@ plug_dependencies = [
         dependency('gobject-2.0'),
         dependency('granite'),
         dependency('gtk+-3.0'),
-        dependency('polkit-gobject-1'),
         dependency('zeitgeist-2.0'),
         meson.get_compiler('vala').find_library('posix'),
+        polkit_dep,
         switchboard_dep
 ]
 


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this switchboard_dep.get_pkgconfig_variable will return a
path from within switchboard's prefix and we cannot write to it.
By using define_variable we can replace the libdir to be from the
paths from meson. This should have no affect on elementaryOS.

---

I also did https://github.com/elementary/switchboard-plug-security-privacy/commit/1b667aa8388c3488c2321df1135d1d5e8392c67d for completion.