### PR TITLE
HouseKeeping: use dngettext instead of ngettext

### DIFF
--- a/src/Views/HouseKeepingPanel.vala
+++ b/src/Views/HouseKeepingPanel.vala
@@ -91,13 +91,13 @@ public class SecurityPrivacy.HouseKeepingPanel : Granite.SimpleSettingsPage {
     }
 
     private void update_days (uint age) {
-        description = ngettext (
+        description = dngettext (Build.GETTEXT_PACKAGE,
             "Old files can be automatically deleted after %u day to save space and help protect your privacy.",
             "Old files can be automatically deleted after %u days to save space and help protect your privacy.",
             age
         ).printf (age);
 
-        file_age_label.label = ngettext (
+        file_age_label.label = dngettext (Build.GETTEXT_PACKAGE,
             "Day",
             "Days",
             age

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -1,3 +1,4 @@
 namespace Build {
     public const string PKGDATADIR = "@PKGDATADIR@";
+    public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
 }


### PR DESCRIPTION
we are inside the domain of the plug and not the application itself.
Fixes #101