### PR TITLE
control: Use generic maintainer address

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: switchboard-plug-security-privacy
 Section: x11
 Priority: optional
-Maintainer: Corentin Noël <tintou@mailoo.org>
+Maintainer: elementary, Inc. <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
                gettext,
                libglib2.0-dev,


### PR DESCRIPTION
Spotted this in the build log.

@tintou Are you OK with this? Do you really want to be the sole maintainer? :wink: 