### PR TITLE
Specify that temp files are unneeded

### DIFF
--- a/src/Views/HouseKeepingPanel.vala
+++ b/src/Views/HouseKeepingPanel.vala
@@ -34,7 +34,7 @@ public class SecurityPrivacy.HouseKeepingPanel : Granite.SimpleSettingsPage {
     construct {
         var switch_header_label = new Granite.HeaderLabel (_("Automatically Delete:"));
 
-        temp_files_switch = new Gtk.CheckButton.with_label (_("Unneeded temporary files"));
+        temp_files_switch = new Gtk.CheckButton.with_label (_("Old temporary files"));
         temp_files_switch.margin_start = 12;
 
         trash_files_switch = new Gtk.CheckButton.with_label (_("Trashed files"));

--- a/src/Views/HouseKeepingPanel.vala
+++ b/src/Views/HouseKeepingPanel.vala
@@ -34,7 +34,7 @@ public class SecurityPrivacy.HouseKeepingPanel : Granite.SimpleSettingsPage {
     construct {
         var switch_header_label = new Granite.HeaderLabel (_("Automatically Delete:"));
 
-        temp_files_switch = new Gtk.CheckButton.with_label (_("Temporary files"));
+        temp_files_switch = new Gtk.CheckButton.with_label (_("Unneeded temporary files"));
         temp_files_switch.margin_start = 12;
 
         trash_files_switch = new Gtk.CheckButton.with_label (_("Trashed files"));


### PR DESCRIPTION
See elementary/onboarding#58. This keeps the text consistent in both places.

I didn't change the text for [`spin_header_label`](https://github.com/elementary/switchboard-plug-security-privacy/blob/master/src/Views/HouseKeepingPanel.vala#L44) because it felt redundant. Should I change that too?