### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ add_project_arguments(
 configuration_data = configuration_data()
 configuration_data.set('PKGDATADIR', pkgdatadir)
 configuration_data.set('GETTEXT_PACKAGE', gettext_name)
+configuration_data.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 
 subdir('data')
 subdir('src')

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -42,6 +42,9 @@ namespace SecurityPrivacy {
         private const string LOCATION = "location";
 
         public Plug () {
+            GLib.Intl.bindtextdomain (Build.GETTEXT_PACKAGE, Build.LOCALEDIR);
+            GLib.Intl.bind_textdomain_codeset (Build.GETTEXT_PACKAGE, "UTF-8");
+
             Object (category: Category.PERSONAL,
                     code_name: "io.elementary.switchboard.security-privacy",
                     display_name: _("Security & Privacy"),

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -1,4 +1,5 @@
 namespace Build {
     public const string PKGDATADIR = "@PKGDATADIR@";
     public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+    public const string LOCALEDIR = "@LOCALEDIR@";
 }


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)