### PR TITLE
TrackPanel: display correct OS name

### DIFF
--- a/src/Views/TrackPanel.vala
+++ b/src/Views/TrackPanel.vala
@@ -100,18 +100,7 @@ public class SecurityPrivacy.TrackPanel : Granite.SimpleSettingsPage {
     }
 
     private static string get_operating_system_name () {
-        string system = _("Your system");
-        try {
-            string contents = null;
-            if (FileUtils.get_contents ("/etc/os-release", out contents)) {
-                int start = contents.index_of ("NAME=") + "NAME=".length;
-                int end = contents.index_of_char ('\n');
-                system = contents.substring (start, end - start).replace ("\"", "");
-            }
-        } catch (FileError e) {
-            debug ("Could not get OS name");
-        }
-        return system;
+        return Environment.get_os_info (GLib.OsInfoKey.NAME) ?? _("Your system");
     }
 
     private void update_status_switch () {


### PR DESCRIPTION
In NixOS, we have the following `/etc/os-release`, the NAME field is not in line 1:

```
BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
BUILD_ID="22.05.20220514.43ff6cb"
DOCUMENTATION_URL="https://nixos.org/learn.html"
HOME_URL="https://nixos.org/"
ID=nixos
LOGO="nix-snowflake"
NAME=NixOS
PRETTY_NAME="NixOS 22.05 (Quokka)"
SUPPORT_URL="https://nixos.org/community.html"
VERSION="22.05 (Quokka)"
VERSION_CODENAME=quokka
VERSION_ID="22.05"
```

Before:

![](https://user-images.githubusercontent.com/20080233/168748837-31edc303-9abd-4586-8150-40bdfcdc7db7.png)

After:

![](https://user-images.githubusercontent.com/20080233/168748980-9bc61e44-5e2b-49b6-bf21-9c6b1b0daed3.png)
