### PR TITLE
Control: bump runtime depends on Settings Daemon to 1.3.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Depends: ${misc:Depends},
          ${shlibs:Depends},
          gala,
          gnome-settings-daemon-common,
-         io.elementary.settings-daemon,
+         io.elementary.settings-daemon (>=1.3.0),
          ufw,
          zeitgeist
 Enhances: switchboard


### PR DESCRIPTION
For new housekeeping settings

Depends on:
- [x] https://github.com/elementary/settings-daemon/pull/65