### PR TITLE
policy: Do not specify the gettext-domain

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,11 +1,5 @@
-gettext_declaration = configure_file(
-    configuration: configuration_data,
-    input: 'security-privacy.policy.in.in',
-    output: '@BASENAME@'
-)
-
 i18n.merge_file(
-    input: gettext_declaration,
+    input: 'security-privacy.policy.in',
     output: gettext_name + '.policy',
     po_dir: meson.project_source_root() / 'po' / 'extra',
     install: true,

--- a/data/security-privacy.policy.in
+++ b/data/security-privacy.policy.in
@@ -7,7 +7,7 @@
   <vendor_url>https://elementary.io/</vendor_url>
 
   <action id="io.elementary.settings.security-privacy">
-    <message gettext-domain="@GETTEXT_PACKAGE@">Authentication is required to run the Firewall Configuration</message>
+    <message>Authentication is required to run the Firewall Configuration</message>
     <icon_name>preferences-system-privacy</icon_name>
     <defaults>
       <allow_any>no</allow_any>

--- a/src/UFWHelpers.vala
+++ b/src/UFWHelpers.vala
@@ -20,10 +20,6 @@
  * Authored by: Corentin Noël <tintou@mailoo.org>
  */
 
-#if TRANSLATION
-    _("Authentication is required to run the Firewall Configuration")
-#endif
-
 namespace SecurityPrivacy.UFWHelpers {
 
     private string get_helper_path () {


### PR DESCRIPTION
Same fix with https://github.com/elementary/switchboard-plug-locale/pull/162 but we embeded the same message in the plug domain thus the message in the polkit dialog is shown as translated as expected.

However, it is better to keep the message only in the policy file for maintainability.