### PR TITLE
policy: Fix removed configure_file by mistake

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,5 +1,11 @@
+gettext_declaration = configure_file(
+    configuration: configuration_data,
+    input: 'security-privacy.policy.in.in',
+    output: '@BASENAME@'
+)
+
 i18n.merge_file(
-    input: 'security-privacy.policy.in',
+    input: gettext_declaration,
     output: gettext_name + '.policy',
     po_dir: meson.project_source_root() / 'po' / 'extra',
     install: true,

--- a/data/security-privacy.policy.in.in
+++ b/data/security-privacy.policy.in.in
@@ -7,7 +7,7 @@
   <vendor_url>https://elementary.io/</vendor_url>
 
   <action id="io.elementary.settings.security-privacy">
-    <message>Authentication is required to run the Firewall Configuration</message>
+    <message gettext-domain="@GETTEXT_PACKAGE@">Authentication is required to run the Firewall Configuration</message>
     <icon_name>preferences-system-privacy</icon_name>
     <defaults>
       <allow_any>no</allow_any>

--- a/data/security-privacy.policy.in.in
+++ b/data/security-privacy.policy.in.in
@@ -7,7 +7,7 @@
   <vendor_url>https://elementary.io/</vendor_url>
 
   <action id="io.elementary.settings.security-privacy">
-    <message gettext-domain="@GETTEXT_PACKAGE@">Authentication is required to run the Firewall Configuration</message>
+    <message>Authentication is required to run the Firewall Configuration</message>
     <icon_name>preferences-system-privacy</icon_name>
     <defaults>
       <allow_any>no</allow_any>

--- a/src/UFWHelpers.vala
+++ b/src/UFWHelpers.vala
@@ -20,10 +20,6 @@
  * Authored by: Corentin Noël <tintou@mailoo.org>
  */
 
-#if TRANSLATION
-    _("Authentication is required to run the Firewall Configuration")
-#endif
-
 namespace SecurityPrivacy.UFWHelpers {
 
     private string get_helper_path () {

--- a/src/UFWHelpers.vala
+++ b/src/UFWHelpers.vala
@@ -20,6 +20,10 @@
  * Authored by: Corentin Noël <tintou@mailoo.org>
  */
 
+#if TRANSLATION
+    _("Authentication is required to run the Firewall Configuration")
+#endif
+
 namespace SecurityPrivacy.UFWHelpers {
 
     private string get_helper_path () {


### PR DESCRIPTION
I overlooked that we still need the configure data for this line:

https://github.com/elementary/switchboard-plug-security-privacy/blob/9bb0aaecb5388efafc62d7d5862e78257d451654/data/security-privacy.policy.in#L17